### PR TITLE
Set credential env var

### DIFF
--- a/bin/awsmfa.js
+++ b/bin/awsmfa.js
@@ -1,67 +1,71 @@
 #!/usr/bin/env node
 
-const execSync = require('child_process').execSync;
-const fs = require('fs');
+const execSync = require('child_process').execSync
+const fs = require('fs')
 
-const profile = process.argv[2];
-const token = process.argv[3];
-const duration = 86400;
+const profile = process.argv[2]
+const token = process.argv[3]
+const duration = 86400
 
-let creds;
-let credentials;
+let creds
+let credentials
 
-const credentialsFile = `${process.env.HOME}/.aws/credentials`;
+const credentialsFile = `${process.env.HOME}/.aws/credentials`
+const cacheEnabled = process.env.AWSMFA_CACHE_ENABLED || false
+const timeoutFile = `${process.env.AWSMFA_TIMEOUT_FILE}`
 
 if (!token) {
-  console.error('Error: no token provided');
-  process.exit(2);
+  console.error('Error: no token provided')
+  process.exit(2)
 }
 
 if (!profile) {
-  console.error('Error: no profile provided');
-  process.exit(2);
+  console.error('Error: no profile provided')
+  process.exit(2)
 }
 
 try {
-  credentials = fs.readFileSync(credentialsFile, 'utf8');
+  credentials = fs.readFileSync(credentialsFile, 'utf8')
 } catch (e) {
-  console.error("Error: couldn't open credentials file");
-  console.error(e.message);
-  process.exit(3);
+  console.error("Error: couldn't open credentials file")
+  console.error(e.message)
+  process.exit(3)
 }
 
-const lines = credentials.split('\n');
+const lines = credentials.split('\n')
 
-const headerRegex = /\[(.*)\]/;
-const optionRegex = /(.*)=(.*)/;
+const headerRegex = /\[(.*)\]/
+const optionRegex = /(.*)=(.*)/
 
-let currentProfile = '';
+let currentProfile = ''
+let currentProfileTimeout
+
 const config = lines.reduce((acc, line) => {
-  const headerMatch = headerRegex.exec(line.trim());
+  const headerMatch = headerRegex.exec(line.trim())
   if (headerMatch) {
-    currentProfile = headerMatch[1];
-    acc[currentProfile] = {};
+    currentProfile = headerMatch[1]
+    acc[currentProfile] = {}
   } else {
-    const optionMatch = optionRegex.exec(line.trim());
+    const optionMatch = optionRegex.exec(line.trim())
     if (optionMatch) {
-      const key = optionMatch[1].trim();
-      const value = optionMatch[2].trim();
-      acc[currentProfile][key] = value;
+      const key = optionMatch[1].trim()
+      const value = optionMatch[2].trim()
+      acc[currentProfile][key] = value
     }
   }
-  return acc;
-}, {});
+  return acc
+}, {})
 
 if (!config[profile]) {
-  console.error(`Error: profile ${profile} not found in credentials file`);
-  process.exit(4);
+  console.error(`Error: profile ${profile} not found in credentials file`)
+  process.exit(4)
 }
 
 const mfaArn = config[profile].mfa_arn;
 
 if (!mfaArn) {
-  console.error(`Error: no mfa_arn defined for profile ${profile}`);
-  process.exit(5);
+  console.error(`Error: no mfa_arn defined for profile ${profile}`)
+  process.exit(5)
 }
 
 try {
@@ -71,28 +75,37 @@ try {
     --token-code ${token} \
     --duration-seconds ${duration} \
     --output json`
-  );
-  creds = JSON.parse(credString).Credentials;
+  )
+
+  creds = JSON.parse(credString).Credentials
+  const now = new Date().getTime() / 1000
+  currentProfileTimeout = new Date(creds.Expiration).getTime() / 1000
+
 } catch (e) {
-  console.error(e.message);
-  process.exit(1);
+  console.error(e.message)
+  process.exit(1)
 }
 
 config.default = {
   aws_access_key_id: creds.AccessKeyId,
   aws_secret_access_key: creds.SecretAccessKey,
   aws_session_token: creds.SessionToken
-};
+}
 
 configString = Object.keys(config).reduce((acc, profile) => {
   acc += `
 
-[${profile}]`;
+[${profile}]`
     Object.keys(config[profile]).forEach(key => {
       acc += `
-${key} = ${config[profile][key]}`;
-    });
-    return acc;
-}, '');
+${key} = ${config[profile][key]}`
+    })
+    return acc
+}, '')
+fs.writeFileSync(credentialsFile, configString)
 
-fs.writeFileSync(credentialsFile, configString);
+if (cacheEnabled) {
+  let exportString = `export AWSMFA_EXPIRE_EPOCH=${currentProfileTimeout}\n`
+  exportString += `export AWSMFA_PROFILE=${profile}\n`
+  fs.writeFileSync(timeoutFile, exportString)
+}

--- a/bin/awsmfa.js
+++ b/bin/awsmfa.js
@@ -13,21 +13,21 @@ let credentials;
 const credentialsFile = `${process.env.HOME}/.aws/credentials`;
 
 if (!token) {
-    console.error('Error: no token provided');
-    process.exit(2);
+  console.error('Error: no token provided');
+  process.exit(2);
 }
 
 if (!profile) {
-    console.error('Error: no profile provided');
-    process.exit(2);
+  console.error('Error: no profile provided');
+  process.exit(2);
 }
 
 try {
-    credentials = fs.readFileSync(credentialsFile, 'utf8');
+  credentials = fs.readFileSync(credentialsFile, 'utf8');
 } catch (e) {
-    console.error("Error: couldn't open credentials file");
-    console.error(e.message);
-    process.exit(3);
+  console.error("Error: couldn't open credentials file");
+  console.error(e.message);
+  process.exit(3);
 }
 
 const lines = credentials.split('\n');
@@ -37,31 +37,31 @@ const optionRegex = /(.*)=(.*)/;
 
 let currentProfile = '';
 const config = lines.reduce((acc, line) => {
-    const headerMatch = headerRegex.exec(line.trim());
-    if (headerMatch) {
-        currentProfile = headerMatch[1];
-        acc[currentProfile] = {};
-    } else {
-        const optionMatch = optionRegex.exec(line.trim());
-        if (optionMatch) {
-            const key = optionMatch[1].trim();
-            const value = optionMatch[2].trim();
-            acc[currentProfile][key] = value;
-        }
+  const headerMatch = headerRegex.exec(line.trim());
+  if (headerMatch) {
+    currentProfile = headerMatch[1];
+    acc[currentProfile] = {};
+  } else {
+    const optionMatch = optionRegex.exec(line.trim());
+    if (optionMatch) {
+      const key = optionMatch[1].trim();
+      const value = optionMatch[2].trim();
+      acc[currentProfile][key] = value;
     }
-    return acc;
+  }
+  return acc;
 }, {});
 
 if (!config[profile]) {
-    console.error(`Error: profile ${profile} not found in credentials file`);
-    process.exit(4);
+  console.error(`Error: profile ${profile} not found in credentials file`);
+  process.exit(4);
 }
 
 const mfaArn = config[profile].mfa_arn;
 
 if (!mfaArn) {
-    console.error(`Error: no mfa_arn defined for profile ${profile}`);
-    process.exit(5);
+  console.error(`Error: no mfa_arn defined for profile ${profile}`);
+  process.exit(5);
 }
 
 try {
@@ -74,22 +74,22 @@ try {
   );
   creds = JSON.parse(credString).Credentials;
 } catch (e) {
-    console.error(e.message);
-    process.exit(1);
+  console.error(e.message);
+  process.exit(1);
 }
 
 config.default = {
-    aws_access_key_id: creds.AccessKeyId,
-    aws_secret_access_key: creds.SecretAccessKey,
-    aws_session_token: creds.SessionToken
+  aws_access_key_id: creds.AccessKeyId,
+  aws_secret_access_key: creds.SecretAccessKey,
+  aws_session_token: creds.SessionToken
 };
 
 configString = Object.keys(config).reduce((acc, profile) => {
-    acc += `
+  acc += `
 
 [${profile}]`;
     Object.keys(config[profile]).forEach(key => {
-        acc += `
+      acc += `
 ${key} = ${config[profile][key]}`;
     });
     return acc;

--- a/bin/awsmfa.js
+++ b/bin/awsmfa.js
@@ -65,14 +65,14 @@ if (!mfaArn) {
 }
 
 try {
-    const credString = execSync(
-        `aws --profile ${profile} sts get-session-token \
-             --serial-number ${mfaArn} \
-             --token-code ${token} \
-             --duration-seconds ${duration}`
-    );
-
-    creds = JSON.parse(credString).Credentials;
+  const credString = execSync(
+    `aws --profile ${profile} sts get-session-token \
+    --serial-number ${mfaArn} \
+    --token-code ${token} \
+    --duration-seconds ${duration} \
+    --output json`
+  );
+  creds = JSON.parse(credString).Credentials;
 } catch (e) {
     console.error(e.message);
     process.exit(1);

--- a/bin/awsmfa.js
+++ b/bin/awsmfa.js
@@ -3,8 +3,8 @@
 const execSync = require('child_process').execSync;
 const fs = require('fs');
 
-const token = process.argv[2];
-const profile = process.argv[3];
+const profile = process.argv[2];
+const token = process.argv[3];
 const duration = 86400;
 
 let creds;

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-   "name": "@vividbytes/awsmfa",
-   "version": "0.0.4",
-   "description": "\"Utility for using 2-factor authentication with AWS CLI\"",
-   "repository": "github:vividbytes/awsmfa",
-   "keywords": [
-      "aws",
-      "cli",
-      "2-factor",
-      "multi-factor",
-      "authentication"
-   ],
-   "author": "Lauri Kinnunen",
-   "license": "MIT",
-   "bin": {
-      "awsmfa": "bin/awsmfa.js"
-   }
+  "name": "@notbrain/awsmfa",
+  "version": "0.1.0",
+  "description": "Utility for using 2-factor authentication with AWS CLI",
+  "repository": "github:notbrain/awsmfa",
+  "keywords": [
+    "aws",
+    "cli",
+    "2-factor",
+    "multi-factor",
+    "authentication"
+  ],
+  "author": "Lauri Kinnunen & Brian Ross",
+  "license": "MIT",
+  "bin": {
+    "awsmfa": "bin/awsmfa.js"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,12 @@
 
 `npm i -g @notbrain/awsmfa` (COMING SOON)
 
+```
+git clone --depth 1 https://github.com/notbrain/awsmfa
+cd awsmfa
+npm i -g 
+```
+
 ## Requirements
 
 Your aws credentials should be located at `~/.aws/credentials` and the file should look something like the one below. You can't have a `[default]` profile because that will be overwritten by this program. `mfa_arn` is the arn of the mfa device that you've registered with a particular IAM user.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## Installation
 
-`npm i -g @vividbytes/awsmfa`
+`npm i -g @notbrain/awsmfa`
 
 ## Requirements
 
@@ -24,7 +24,7 @@ After installation you should have access to the `awsmfa` command. The first arg
 
 **Example**
 
-`awsmfa 382973 profile-1`
+`awsmfa profile-1 382973`
 
 The commmand adds a `[default]` profile to your credentials file with a session-token. The session is valid for 24 hours. The credentials file would now look something like this.
 

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ mfa_arn = arn:aws:iam::lsfaiselfjlaskjkda:mfa/profile-2
 
 ## Usage
 
-After installation you should have access to the `awsmfa` command. The first argument is the mfa token and the second argument is the profile you want to use.
+After installation you should have access to the `awsmfa` command. The first argument is the profile you want to use and the second argument is the MFA token.
 
 **Example**
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 ## Installation
 
 ```
-npm i -g @notbrain/awsmfa` (COMING SOON)
+npm i -g @notbrain/awsmfa (COMING SOON)
 ```
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,8 @@
 ## Installation
 
-`npm i -g @notbrain/awsmfa` (COMING SOON)
+```
+npm i -g @notbrain/awsmfa` (COMING SOON)
+```
 
 ```
 git clone --depth 1 https://github.com/notbrain/awsmfa

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## Installation
 
-`npm i -g @notbrain/awsmfa`
+`npm i -g @notbrain/awsmfa` (COMING SOON)
 
 ## Requirements
 


### PR DESCRIPTION
Added support for storing the epoch time in seconds into a shell variable so shell prompt integrations  do not need to call aws iam get-user on every new prompt. They can now just show the seconds remaining on the token lease. 

Example `[voltaint <expiration>]` expiring in 85509 seconds:

![image](https://user-images.githubusercontent.com/67282/84159976-89755700-aa22-11ea-86e4-da52f106c49e.png)

